### PR TITLE
Adapt for multibyte strings as UTF-8

### DIFF
--- a/src/MatchesSolver.php
+++ b/src/MatchesSolver.php
@@ -46,7 +46,7 @@ class MatchesSolver extends Solver
         array $matrix
     ) {
         return array_map(function (Match $result) use ($stringA) {
-            $result->value = substr($stringA, $result->index(), $result->length);
+            $result->value = mb_substr($stringA, $result->index(), $result->length);
 
             return $result;
         }, $longestIndexes);

--- a/src/Solver.php
+++ b/src/Solver.php
@@ -37,7 +37,7 @@ class Solver implements SolverInterface
         string $stringB,
         array $matrix
     ) {
-        return count($longestIndexes) === 0 ? '' : substr($stringA, $longestIndexes[0], $longestLength);
+        return count($longestIndexes) === 0 ? '' : mb_substr($stringA, $longestIndexes[0], $longestLength);
     }
 
     /**
@@ -55,8 +55,14 @@ class Solver implements SolverInterface
             return call_user_func_array([$this, 'solve'], $arguments);
         }
 
-        $charsA = str_split($stringA);
-        $charsB = str_split($stringB);
+        $charsA = [];
+        $charsB = [];
+        for ($i=0; $i < max(mb_strlen($stringA), 1); $i++) {
+                $charsA[] = mb_substr($stringA, $i, 1);
+        }
+        for ($i=0; $i < max(mb_strlen($stringB), 1); $i++) {
+                $charsB[] = mb_substr($stringB, $i, 1);
+        }
 
         $matrix = array_fill_keys(array_keys($charsA), array_fill_keys(array_keys($charsB), 0));
         $longestLength = 0;

--- a/test/suite/MatchesArrayProvidersTrait.php
+++ b/test/suite/MatchesArrayProvidersTrait.php
@@ -55,6 +55,29 @@ trait MatchesArrayProvidersTrait
                     ],
                 ],
             ],
+            'UTF-8'              => [
+                'L’été était chaud.',
+                'L’hiver était froid.',
+                [
+                    [
+                        'value'   => ' était ',
+                        'length'  => 7,
+                        'indexes' => [5, 7],
+                    ],
+                ],
+            ],
+            // In UTF-8: é = 0xC3A9 and © = 0xC2A9 (the last byte is the same but the Unicode characters are different)
+            'UTF-8 (nasty)'      => [
+                'L’été était chaud.',
+                'L’hiver ©tait froid.',
+                [
+                    [
+                        'value'   => 'tait ',
+                        'length'  => 5,
+                        'indexes' => [7, 9],
+                    ],
+                ],
+            ],
         ];
     }
 }


### PR DESCRIPTION
There is no native function mb_str_split, hence writing a loop.

In most cases there are no differences in matches, but there are differences in lengths and indexes. The first added test illustrates this, the previous version gives the same match, but its length was 8 instead of 7 (the "é" counts as 2 bytes) and indexes were 9 / 9 instead of 5 / 7 (the "é" counts as 2 bytes and "’" counts as 3 bytes).

The second test illustrates that in some cases there could be differences in matches because UTF-8 is a multibyte encoding and some individual bytes could match although the whole characters won’t match.